### PR TITLE
Remove Triton

### DIFF
--- a/inference.json
+++ b/inference.json
@@ -5,11 +5,6 @@
       "git": "https://github.com/kserve/kserve"
     },
     {
-      "name": "triton",
-      "packageManager": "PYPI",
-      "git": "https://github.com/openai/triton"
-    },
-    {
       "name": "torchserve",
       "packageManager": "PYPI",
       "git": "https://github.com/pytorch/serve"


### PR DESCRIPTION
- Removes triton from feed due to name overlap with: https://github.com/tritonmc/Triton

In the future we can address this issue by filtering for vendors when we ingest data from NVD.